### PR TITLE
Permitir LowerCase para Usuário no Demo e Alterar ContentType

### DIFF
--- a/samples/src/view/View.Samples.dfm
+++ b/samples/src/view/View.Samples.dfm
@@ -153,7 +153,6 @@ object FrmSamples: TFrmSamples
       Top = 194
       Width = 269
       Height = 21
-      CharCase = ecLowerCase
       TabOrder = 6
     end
     object edtPassword: TEdit

--- a/src/Mail4Delphi.Intf.pas
+++ b/src/Mail4Delphi.Intf.pas
@@ -20,6 +20,7 @@ type
     function AddAttachment(const AFile: string): IMail;
     function Auth(const AValue: Boolean): IMail;
     function SSL(const AValue: Boolean): IMail;
+    function ContentType(const AValue: string): IMail;
     function Clear: IMail;
     function SendMail: Boolean;
     function SetUpEmail: Boolean;

--- a/src/Mail4Delphi.pas
+++ b/src/Mail4Delphi.pas
@@ -42,6 +42,7 @@ type
     function AddAttachment(const AFile: string): IMail;
     function Auth(const AValue: Boolean): IMail;
     function SSL(const AValue: Boolean): IMail;
+    function ContentType(const AValue: string): IMail;
     function Clear: IMail;
     function SendMail: Boolean;
     class function New: IMail;
@@ -159,6 +160,12 @@ function TMail.Clear: IMail;
 begin
   FIdMessage.Clear;
   FIdText.Body.Clear;
+  Result := Self;
+end;
+
+function TMail.ContentType(const AValue: string): IMail;
+begin
+  FIdText.ContentType := AValue;
   Result := Self;
 end;
 


### PR DESCRIPTION
- No Amazon AWS (SES) não se utiliza e-mails como usuário mas sim logins aleatórios, contendo maiúsculas e minúsculas.
- Criado opção para poder definir o **ContentType**, pois no Amazon SES,  não é aceito o ContentType **text/html; text/plain;**